### PR TITLE
Feature/story grouping

### DIFF
--- a/src/componentMetadata.ts
+++ b/src/componentMetadata.ts
@@ -16,6 +16,6 @@ export default (id: string, content: SDCSchema): ComponentMetadata => {
     machineName: id,
     status: content.status || 'stable',
     name: content.name,
-    group: content.group || 'All Components',
+    group: content.group,
   }
 }


### PR DESCRIPTION
Add group-based categorisation for YAML stories
- Use group property from component definition if available.
- Fallback to folder hierarchy under ./components.
- Default to SDC when no subfolders exist.
- Capitalise group name in Storybook baseTitle.