### PR TITLE
feat: Handle attributes in props for SDC components

### DIFF
--- a/src/storiesGenerator.ts
+++ b/src/storiesGenerator.ts
@@ -21,7 +21,7 @@ export const ${capitalize(storyKey)} = {
   name: ${JSON.stringify(name ?? capitalize(storyKey), null, 2)},
   args: {
     ...Basic.baseArgs,
-    ${generateArgs(props, false)}
+    ${processPropsAttributes(props)}
     ${generateArgs(slots, true)}
     ${generateVariants(variants)}
   },
@@ -57,4 +57,23 @@ const generateVariants = (
         `${variantKey}: ${JSON.stringify(variantValue.title)},`
     )
     .join('\n')
+}
+
+// Processes the 'attributes' prop to convert it to defaultAttributes array format
+const processPropsAttributes = (props: Record<string, any>): string => {
+  if (!props || !props.attributes || Object.keys(props.attributes).length === 0) {
+    return generateArgs(props, false)
+  }
+  
+  // Clone props without attributes
+  const { attributes, ...otherProps } = props
+  const propsArgs = generateArgs(otherProps, false)
+  
+  // Convert attributes object to array-of-tuples format for Twig Attribute
+  // Same format as defaultAttributes: [['key', 'value'], ['key2', 'value2']]
+  const attributeEntries = Object.entries(attributes)
+    .map(([key, value]) => `['${key}', ${JSON.stringify(value)}]`)
+    .join(', ')
+  
+  return propsArgs + (propsArgs ? '\n' : '') + `defaultAttributes: [...Basic.baseArgs.defaultAttributes || [], ${attributeEntries}],`
 }


### PR DESCRIPTION
Add processPropsAttributes() function to support the current Drupal SDC pattern where HTML attributes are passed via props.attributes.

This function:
- Extracts the 'attributes' object from props
- Converts it to the defaultAttributes array-of-tuples format
- Merges it with existing defaultAttributes from baseArgs

This enables proper HTML attribute rendering (src, srcset, alt, aria-*, data-*, etc.) in Storybook stories using the same pattern as Drupal backend code: #props['attributes'].

Related to #82 