### PR TITLE
Fix/sanitize story key numeric prefix

### DIFF
--- a/src/storiesGenerator.ts
+++ b/src/storiesGenerator.ts
@@ -61,19 +61,27 @@ const generateVariants = (
 
 // Processes the 'attributes' prop to convert it to defaultAttributes array format
 const processPropsAttributes = (props: Record<string, any>): string => {
-  if (!props || !props.attributes || Object.keys(props.attributes).length === 0) {
+  if (
+    !props ||
+    !props.attributes ||
+    Object.keys(props.attributes).length === 0
+  ) {
     return generateArgs(props, false)
   }
-  
+
   // Clone props without attributes
   const { attributes, ...otherProps } = props
   const propsArgs = generateArgs(otherProps, false)
-  
+
   // Convert attributes object to array-of-tuples format for Twig Attribute
   // Same format as defaultAttributes: [['key', 'value'], ['key2', 'value2']]
   const attributeEntries = Object.entries(attributes)
     .map(([key, value]) => `['${key}', ${JSON.stringify(value)}]`)
     .join(', ')
-  
-  return propsArgs + (propsArgs ? '\n' : '') + `defaultAttributes: [...Basic.baseArgs.defaultAttributes || [], ${attributeEntries}],`
+
+  return (
+    propsArgs +
+    (propsArgs ? '\n' : '') +
+    `defaultAttributes: [...Basic.baseArgs.defaultAttributes || [], ${attributeEntries}],`
+  )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,12 @@ export const deriveGroupFromPath = (fileName: string) => {
 
   return 'SDC'
 }
+
+// Sanitize story key to ensure it's a valid JavaScript identifier
+export const sanitizeStoryKey = (key: string): string => {
+  // If key starts with a digit, prefix it with an underscore
+  if (/^\d/.test(key)) {
+    return `_${key}`
+  }
+  return key
+}

--- a/src/vite-plugin-storybook-yaml-stories.ts
+++ b/src/vite-plugin-storybook-yaml-stories.ts
@@ -1,8 +1,9 @@
 import { readdirSync, readFileSync } from 'fs'
 import { parse as parseYaml } from 'yaml'
-import { join, basename, dirname, extname, relative, sep } from 'path'
+import { join, basename, dirname, extname } from 'path'
 import { globSync } from 'glob'
 import { logger } from './logger.ts'
+import { sanitizeStoryKey } from './utils.ts'
 
 import type {
   Args,
@@ -212,9 +213,9 @@ export default {
 };
 
 export const Basic = {
-  
+
   args: ${JSON.stringify(basicArgs, null, 2)},
-  baseArgs: ${JSON.stringify(args, null, 2)}, 
+  baseArgs: ${JSON.stringify(args, null, 2)},
   play: async ({ canvasElement }) => {
     Drupal.attachBehaviors(canvasElement, window.drupalSettings);
   },
@@ -260,15 +261,6 @@ export const yamlStoriesIndexer: Indexer = {
       throw error
     }
   },
-}
-
-// Sanitize story key to ensure it's a valid JavaScript identifier
-const sanitizeStoryKey = (key: string): string => {
-  // If key starts with a digit, prefix it with an underscore
-  if (/^\d/.test(key)) {
-    return `_${key}`
-  }
-  return key
 }
 
 // Load *.story.yml files.


### PR DESCRIPTION
Adds a `sanitizeStoryKey()` function that prefixes story keys with `_` if they start with a digit
Prevents "Invalid or unexpected token" errors when story filenames like `image.16x9.story.yml` are used
Story files starting with numbers now generate valid JavaScript exports like `export const _16x9`

Fixes #103 